### PR TITLE
添加对colab的支持（尽管不能用）

### DIFF
--- a/colab_webui_vc.ipynb
+++ b/colab_webui_vc.ipynb
@@ -1,0 +1,128 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/huangxu1991/GPT-SoVITS-VC/blob/main/colab_webui_vc.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "e9b7iFV3dm1f"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Environment 环境配置\n",
+        "!pip install -q condacolab\n",
+        "# Setting up condacolab and installing packages\n",
+        "import condacolab\n",
+        "condacolab.install_from_url(\"https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Linux-x86_64.sh\")\n",
+        "%cd -q /content\n",
+        "!git clone https://github.com/huangxu1991/GPT-SoVITS-VC\n",
+        "!conda install -y -q -c pytorch -c nvidia cudatoolkit\n",
+        "%cd -q /content/GPT-SoVITS-VC\n",
+        "!conda install -y -q -c conda-forge gcc gxx ffmpeg cmake -c pytorch -c nvidia\n",
+        "!/usr/local/bin/pip install -r requirements.txt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0NgxXg5sjv7z"
+      },
+      "outputs": [],
+      "source": [
+        "# @title Download pretrained models 下载预训练模型\n",
+        "!mkdir -p /content/GPT-SoVITS-VC/GPT_SoVITS/pretrained_models\n",
+        "%cd /content/GPT-SoVITS-VC/GPT_SoVITS/pretrained_models\n",
+        "!git clone https://huggingface.co/lj1995/GPT-SoVITS\n",
+        "!git config core.sparseCheckout true\n",
+        "!mv /content/GPT-SoVITS-VC/GPT_SoVITS/pretrained_models/GPT-SoVITS/* /content/GPT-SoVITS-VC/GPT_SoVITS/pretrained_models/"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "q9UG6uKIZ4QU"
+      },
+      "outputs": [],
+      "source": [
+        "# @title （可选）将语言切换为中文\n",
+        "%mv /content/GPT-SoVITS-VC/i18n/locale/en_US.json /content/GPT-SoVITS-VC/i18n/locale/en_US.json1\n",
+        "%mv /content/GPT-SoVITS-VC/i18n/locale/zh_CN.json /content/GPT-SoVITS-VC/i18n/locale/en_US.json"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "z_nEkMXtYekD"
+      },
+      "outputs": [],
+      "source": [
+        "# @title launch WebUI 启动WebUI（需要先启动之后关闭才能启动vc_webui.py）\n",
+        "!/usr/local/bin/pip install ipykernel\n",
+        "!/usr/local/bin/pip install feature_extractor\n",
+        "!sed -i '10s/False/True/' /content/GPT-SoVITS-VC/config.py\n",
+        "%cd /content/GPT-SoVITS-VC/\n",
+        "!/usr/local/bin/python  webui.py"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4oRGUzkrk8C7"
+      },
+      "outputs": [],
+      "source": [
+        "# @title launch WebUI（VC） 启动WebUI（VC）\n",
+        "!/usr/local/bin/pip install ipykernel\n",
+        "!/usr/local/bin/pip install feature_extractor\n",
+        "!sed -i '10s/False/True/' /content/GPT-SoVITS-VC/config.py\n",
+        "%cd /content/GPT-SoVITS-VC/\n",
+        "!/usr/local/bin/python  vc_webui.py"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ksEIz7tpXPwO"
+      },
+      "outputs": [],
+      "source": [
+        "# @title 安装其它模型（推理非必要）\n",
+        "# 安装asr模型\n",
+        "!mkdir -p /content/GPT-SoVITS-VC/tools/asr/models\n",
+        "!mkdir -p /content/GPT-SoVITS-VC/tools/uvr5\n",
+        "%cd /content/GPT-SoVITS-VC/tools/asr/models\n",
+        "!git clone https://www.modelscope.cn/damo/speech_paraformer-large_asr_nat-zh-cn-16k-common-vocab8404-pytorch.git\n",
+        "!git clone https://www.modelscope.cn/damo/speech_fsmn_vad_zh-cn-16k-common-pytorch.git\n",
+        "!git clone https://www.modelscope.cn/damo/punc_ct-transformer_zh-cn-common-vocab272727-pytorch.git\n",
+        "# 安装uvr5模型\n",
+        "%cd /content/GPT-SoVITS-VC/tools/uvr5\n",
+        "%rm -r uvr5_weights\n",
+        "!git clone https://huggingface.co/Delik/uvr5_weights\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
colab_webui_vc.ipynb的添加。
在colab用main分支的vc_webui测试过，目前可以启动，但没有外链，所以不可用。
根据推测，应该是vc_webui本身的问题。
还有一个BUG：
如果在环境配置好之后直接启动会报错找不到库feature_extractor，即使在用pip list确认安装好之后也报错，需要先运行一遍原版的webui才行。